### PR TITLE
新增错误消息返回方法，用于返回给前台业务错误

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -67,3 +67,24 @@ func Code(err error) (int32, bool) {
 
 	return 0, false
 }
+
+
+// MetaError 新建meta错误
+//
+// 为了避免与httpStatus错误冲突，错误码及错误信息将放在meta中。
+// 返回 httpStatus 为 200。
+// 返回案例如下：
+// {
+//    "code": "",
+//    "msg": "",
+//    "meta": {
+//        "code": "@code",
+//        "msg": "@err"
+//    }
+// }
+func MetaError(code int32, err string) twirp.Error {
+	ne := twirp.NewError(twirp.NoError, "")
+	ne = ne.WithMeta("code", fmt.Sprintf("%v", code))
+	ne = ne.WithMeta("msg", err)
+	return ne
+}


### PR DESCRIPTION
为了避免与httpStatus错误冲突，错误码及错误信息将放在meta中。
返回 httpStatus 为 200。
返回案例如下：
{
   "code": "",
   "msg": "",
   "meta": {
       "code": "@code",
       "msg": "@err"
   }
}